### PR TITLE
Updated benchmark code to match newest versions of picobench

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -12,7 +12,8 @@ int main(int argc, char *argv[]) {
   runner.parse_cmd_line(argc, argv);
   if (runner.should_run()) {
     runner.set_default_state_iterations({1600000});
-    auto report = runner.run_benchmarks();
+    runner.run_benchmarks();
+    auto report = runner.generate_report();
     report.to_text(std::cout);
   }
   return 0;


### PR DESCRIPTION
Hi,

I was trying to use your ART In a personal project and realised the benchmarks would not compile with the newest versions of Picobench. 

Picobench has split the running phase and the report generation in two different method calls, so I updated that. 