### PR TITLE
bugfix: 'node_16<T>::grow()' partial_key index offset inconsistent

### DIFF
--- a/include/art/node_16.hpp
+++ b/include/art/node_16.hpp
@@ -115,7 +115,7 @@ template <class T> inner_node<T> *node_16<T>::grow() {
   new_node->n_children_ = this->n_children_;
   std::copy(this->children_, this->children_ + this->n_children_, new_node->children_);
   for (int i = 0; i < n_children_; ++i) {
-    new_node->indexes_[(uint8_t) this->keys_[i]] = i;
+    new_node->indexes_[128 + (uint8_t) this->keys_[i]] = i;
   }
   delete this;
   return new_node;


### PR DESCRIPTION
This issue was discovered when using the iterator to traverse and output text.

The functions in `node_48.hpp` will all add an offset of `128` when indexing using `partial_key`, for example:

```cpp
node_48<T>::find_child(char partial_key){
    uint8_t index = indexes_[128 + partial_key];
    //...
}
```

However, `node_16<T>::grow()` ignores this point and directly uses the `partial_key` stored in `keys_` as the index, causing an offset in indexing when the node grows:

```cpp
template <class T> inner_node<T> *node_16<T>::grow() {
  //...
  for (int i = 0; i < n_children_; ++i) {
    new_node->indexes_[(uint8_t) this->keys_[i]] = i;
  }  //...
}
```

For example, consider a `node_16` instance:

```text
node_16:
keys_: [a, b, ...]
ASCII: [97, 98, ...]
node_16<T>::grow()
indexes_: [..., 0, ..., EMPTY, ...]
        wrong [97]  correct[97+128]
```

When querying `a` in `node_48`, `find_child()` will index `indexes_[128 + 97]`, but the value there is `EMPTY`. Moreover, this error will also affect the correctness of functions like `node_48<T>::next_partial_key`, causing iterators to obtain incorrect values of `keys_`, and so on.

<img width="306" alt="Screenshot 2024-03-14 at 10 29 11 PM" src="https://github.com/rafaelkallis/adaptive-radix-tree/assets/35755846/7b74319c-a330-4f4b-9c79-d03d7a809479">

The iterator in the figure obtained an incorrect value of -55 through `node_48<T>::next_partial_key`. This node was grown from a `node_16`, where the original key stored at that position was `I` (73). `node_48<T>::next_partial_key(-128)` start from `-128+128` with an offset of `73` to get `I`, but `partial_key` remains `-128+73=-55`.